### PR TITLE
Update MintAndBurn.java

### DIFF
--- a/src/main/java/com/bloxbean/cardano/client/examples/MintAndBurn.java
+++ b/src/main/java/com/bloxbean/cardano/client/examples/MintAndBurn.java
@@ -319,7 +319,7 @@ public class MintAndBurn extends BaseTest {
                     markedForRemoval.add(ma);
             });
 
-            multiAssets.removeAll(markedForRemoval);
+            if (markedForRemoval != null && !markedForRemoval.isEmpty()) multiAssets.removeAll(markedForRemoval);
         }
     }
 


### PR DESCRIPTION
multiAssets.removeAll(markedForRemoval)throws UnsupportedException if markedForRemoval list is empty.